### PR TITLE
Explicitly set db container name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ db:
         image: postgres:9.4
         ports:
                 - "5432"
+        container_name: "db"
 scheduler:
         build: .
         volumes:
@@ -9,5 +10,5 @@ scheduler:
         ports:
                 - "3000:3000"
         environment:
-                DATABASE_URL: "postgresql://postgres@schedulerdockerised_db_1/"
+                DATABASE_URL: "postgresql://postgres@db/"
 


### PR DESCRIPTION
Adding a container name for db container, removing _ from host name Fixes #2
